### PR TITLE
Fix PR3 review follow-ups

### DIFF
--- a/process.py
+++ b/process.py
@@ -3,13 +3,7 @@ import xml.etree.ElementTree as ET
 
 import pandas as pd
 
-
-METRIC_COLUMNS = ['发病数', '死亡数', '发病率(1/10万)', '死亡率(1/10万)']
-DATE_COLUMNS = ['年份', '月份']
-DIMENSION_LABELS = {
-    'age': '年龄分组',
-    'region': '地区',
-}
+from schema import DATE_COLUMNS, METRIC_COLUMNS, get_dimension_column, get_output_columns
 
 
 def parse_excel_xml(xml_file: str) -> pd.DataFrame:
@@ -46,7 +40,7 @@ def parse_excel_xml(xml_file: str) -> pd.DataFrame:
     max_cols = max((len(row) for row in data), default=0)
     normalized_data = [row + [''] * (max_cols - len(row)) for row in data]
     df = pd.DataFrame(normalized_data)
-    # 跳过标题和空白行，去掉最右侧汇总行。
+    # 跳过标题和空白行，去掉最下方的汇总行。
     df = df.iloc[3 : len(df) - 1, 1:]
     df = df.reset_index(drop=True)
     df.columns = range(df.shape[1])
@@ -54,7 +48,7 @@ def parse_excel_xml(xml_file: str) -> pd.DataFrame:
     return df.astype('float', errors='ignore')
 
 
-def load_template_columns(template_file: str, dimension_col: str) -> list[str]:
+def load_template_columns(template_file: str, data_type: str) -> list[str]:
     """Load header labels and normalize historical template files to the current schema."""
     template_values = (
         pd.read_csv(template_file, encoding='utf-8-sig', header=None)
@@ -63,13 +57,10 @@ def load_template_columns(template_file: str, dimension_col: str) -> list[str]:
         .astype(str)
         .tolist()
     )
-    expected_columns = [dimension_col, *METRIC_COLUMNS, *DATE_COLUMNS]
+    expected_columns = get_output_columns(data_type)
 
-    if len(template_values) == len(expected_columns):
-        return [dimension_col, *template_values[1:]]
-
-    if len(template_values) > len(expected_columns):
-        return [dimension_col, *template_values[1 : 1 + len(METRIC_COLUMNS)], *template_values[-2:]]
+    if len(template_values) >= len(expected_columns):
+        return expected_columns
 
     raise ValueError(
         f'模板文件列数不足：{template_file}，'
@@ -85,14 +76,13 @@ def main() -> None:
 
     disease_id = int(input('请输入疾病ID：'))
     data_type = input('请输入处理类型（age/region）：').strip().lower()
-    if data_type not in DIMENSION_LABELS:
-        raise ValueError('处理类型必须是 age 或 region')
+    dimension_col = get_dimension_column(data_type)
 
     foldername = str(disease_id)
     os.makedirs(foldername, exist_ok=True)
 
     template_file = f'template_{data_type}.csv'
-    template_columns = load_template_columns(template_file, DIMENSION_LABELS[data_type])
+    template_columns = load_template_columns(template_file, data_type)
     expected_monthly_columns = len(template_columns) - len(DATE_COLUMNS)
     final_df = pd.DataFrame(columns=template_columns)
 
@@ -111,7 +101,7 @@ def main() -> None:
                     f'期望 {expected_monthly_columns} 列，实际 {monthly_df.shape[1]} 列。'
                 )
 
-            monthly_df.columns = template_columns[:-2]
+            monthly_df.columns = [dimension_col, *METRIC_COLUMNS]
             monthly_df['年份'] = year
             monthly_df['月份'] = month
             final_df = pd.concat([final_df, monthly_df], axis=0, ignore_index=True)

--- a/schema.py
+++ b/schema.py
@@ -1,0 +1,20 @@
+METRIC_COLUMNS = ['发病数', '死亡数', '发病率(1/10万)', '死亡率(1/10万)']
+DATE_COLUMNS = ['年份', '月份']
+DIMENSION_COLUMNS = {
+    'age': '年龄分组',
+    'region': '地区',
+}
+
+
+def get_dimension_column(data_type: str) -> str:
+    if data_type not in DIMENSION_COLUMNS:
+        raise ValueError('类型必须是 age 或 region')
+    return DIMENSION_COLUMNS[data_type]
+
+
+def get_output_columns(data_type: str) -> list[str]:
+    return [get_dimension_column(data_type), *METRIC_COLUMNS, *DATE_COLUMNS]
+
+
+def get_required_columns(data_type: str) -> list[str]:
+    return get_output_columns(data_type)

--- a/sum_script.py
+++ b/sum_script.py
@@ -2,19 +2,13 @@ import os
 
 import pandas as pd
 
-
-GROUP_COLUMNS = {
-    'age': '年龄分组',
-    'region': '地区',
-}
-NUMERIC_COLUMNS = ['发病数', '死亡数', '发病率(1/10万)', '死亡率(1/10万)']
+from schema import METRIC_COLUMNS, get_dimension_column, get_required_columns
 
 
 def main() -> None:
     disease_id = int(input('请输入疾病ID：'))
     data_type = input('请输入汇总类型（age/region）：').strip().lower()
-    if data_type not in GROUP_COLUMNS:
-        raise ValueError('汇总类型必须是 age 或 region')
+    group_col = get_dimension_column(data_type)
 
     foldername = str(disease_id)
     os.makedirs(foldername, exist_ok=True)
@@ -26,8 +20,7 @@ def main() -> None:
     df = pd.read_csv(source_file, encoding='gbk')
     df.columns = [col.lstrip('\ufeff') if isinstance(col, str) else col for col in df.columns]
 
-    group_col = GROUP_COLUMNS[data_type]
-    required_columns = [group_col, '年份', *NUMERIC_COLUMNS]
+    required_columns = get_required_columns(data_type)
     missing_columns = [col for col in required_columns if col not in df.columns]
     if missing_columns:
         raise KeyError(
@@ -35,20 +28,23 @@ def main() -> None:
             '请确认文件表头是否正确，且 process.py 的处理类型与当前汇总类型一致。'
         )
 
-    for col in NUMERIC_COLUMNS:
+    for col in METRIC_COLUMNS:
         df[col] = pd.to_numeric(df[col], errors='coerce').fillna(0)
 
     df['年份'] = pd.to_numeric(df['年份'], errors='coerce')
     df = df.dropna(subset=['年份']).copy()
     df['年份'] = df['年份'].astype(int)
 
+    cases_col, deaths_col, incidence_col, mortality_col = METRIC_COLUMNS
     yearly_df = (
         df.groupby([group_col, '年份'], as_index=False)
         .agg(
-            发病数=('发病数', 'sum'),
-            死亡数=('死亡数', 'sum'),
-            **{'发病率(1/10万)': ('发病率(1/10万)', 'mean')},
-            **{'死亡率(1/10万)': ('死亡率(1/10万)', 'mean')},
+            **{
+                cases_col: (cases_col, 'sum'),
+                deaths_col: (deaths_col, 'sum'),
+                incidence_col: (incidence_col, 'mean'),
+                mortality_col: (mortality_col, 'mean'),
+            }
         )
         .sort_values([group_col, '年份'], ignore_index=True)
     )


### PR DESCRIPTION
### Summary
- move shared age/region column schema into a single `schema.py` module used by both `process.py` and `sum_script.py`
- update `process.py` to use the shared schema helpers when normalizing template headers and assigning parsed monthly columns
- fix the `parse_excel_xml()` comment so it matches the actual slice behavior (`len(df) - 1` drops the bottom summary row)

### Why
This addresses the remaining review feedback on PR #3:
- Copilot's comment about the misleading "最右侧汇总行" wording
- Cursor Bugbot's note that the two scripts duplicated the same column contract independently

### Verification
- `python -m py_compile schema.py process.py sum_script.py download.py`
- ran `process.py` for disease `139`, years `2004-2020`, mode `region`
- ran `sum_script.py` for disease `139`, mode `region`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes shared column names and validation; primary behavior change is stricter/clearer template header normalization and consistent column assignment, which could surface schema mismatches earlier.
> 
> **Overview**
> **Unifies the column schema used by `process.py` and `sum_script.py`.** Shared metric/date/dimension column definitions and helpers are moved into a new `schema.py`, and both scripts now call `get_dimension_column()` / `get_output_columns()` / `get_required_columns()` instead of maintaining duplicate mappings.
> 
> `process.py` now normalizes template headers by returning the canonical output columns when the template has enough columns, assigns parsed monthly data columns explicitly as `[dimension, *METRIC_COLUMNS]`, and fixes a misleading comment to reflect that the slice drops the *bottom* summary row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9114a04f70d714cf6b5e179eadc68e02bd455e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->