### PR TITLE
Fix PR4 review follow-ups

### DIFF
--- a/process.py
+++ b/process.py
@@ -3,7 +3,7 @@ import xml.etree.ElementTree as ET
 
 import pandas as pd
 
-from schema import DATE_COLUMNS, METRIC_COLUMNS, get_dimension_column, get_output_columns
+from schema import DATE_COLUMNS, METRIC_COLUMNS, get_dimension_column, get_final_csv_columns
 
 
 def parse_excel_xml(xml_file: str) -> pd.DataFrame:
@@ -48,8 +48,8 @@ def parse_excel_xml(xml_file: str) -> pd.DataFrame:
     return df.astype('float', errors='ignore')
 
 
-def load_template_columns(template_file: str, data_type: str) -> list[str]:
-    """Load header labels and normalize historical template files to the current schema."""
+def validate_template_and_get_output_columns(template_file: str, data_type: str) -> list[str]:
+    """Validate the template width and return the canonical final.csv schema."""
     template_values = (
         pd.read_csv(template_file, encoding='utf-8-sig', header=None)
         .iloc[0]
@@ -57,7 +57,7 @@ def load_template_columns(template_file: str, data_type: str) -> list[str]:
         .astype(str)
         .tolist()
     )
-    expected_columns = get_output_columns(data_type)
+    expected_columns = get_final_csv_columns(data_type)
 
     if len(template_values) >= len(expected_columns):
         return expected_columns
@@ -77,12 +77,13 @@ def main() -> None:
     disease_id = int(input('请输入疾病ID：'))
     data_type = input('请输入处理类型（age/region）：').strip().lower()
     dimension_col = get_dimension_column(data_type)
+    year_col, month_col = DATE_COLUMNS
 
     foldername = str(disease_id)
     os.makedirs(foldername, exist_ok=True)
 
     template_file = f'template_{data_type}.csv'
-    template_columns = load_template_columns(template_file, data_type)
+    template_columns = validate_template_and_get_output_columns(template_file, data_type)
     expected_monthly_columns = len(template_columns) - len(DATE_COLUMNS)
     final_df = pd.DataFrame(columns=template_columns)
 
@@ -102,8 +103,8 @@ def main() -> None:
                 )
 
             monthly_df.columns = [dimension_col, *METRIC_COLUMNS]
-            monthly_df['年份'] = year
-            monthly_df['月份'] = month
+            monthly_df[year_col] = year
+            monthly_df[month_col] = month
             final_df = pd.concat([final_df, monthly_df], axis=0, ignore_index=True)
 
     output_file = os.path.join(foldername, 'final.csv')

--- a/schema.py
+++ b/schema.py
@@ -12,9 +12,9 @@ def get_dimension_column(data_type: str) -> str:
     return DIMENSION_COLUMNS[data_type]
 
 
-def get_output_columns(data_type: str) -> list[str]:
+def get_final_csv_columns(data_type: str) -> list[str]:
     return [get_dimension_column(data_type), *METRIC_COLUMNS, *DATE_COLUMNS]
 
 
-def get_required_columns(data_type: str) -> list[str]:
-    return get_output_columns(data_type)
+def get_summary_required_columns(data_type: str) -> list[str]:
+    return [get_dimension_column(data_type), *METRIC_COLUMNS, DATE_COLUMNS[0]]

--- a/sum_script.py
+++ b/sum_script.py
@@ -2,13 +2,14 @@ import os
 
 import pandas as pd
 
-from schema import METRIC_COLUMNS, get_dimension_column, get_required_columns
+from schema import DATE_COLUMNS, METRIC_COLUMNS, get_dimension_column, get_summary_required_columns
 
 
 def main() -> None:
     disease_id = int(input('请输入疾病ID：'))
     data_type = input('请输入汇总类型（age/region）：').strip().lower()
     group_col = get_dimension_column(data_type)
+    year_col = DATE_COLUMNS[0]
 
     foldername = str(disease_id)
     os.makedirs(foldername, exist_ok=True)
@@ -20,7 +21,7 @@ def main() -> None:
     df = pd.read_csv(source_file, encoding='gbk')
     df.columns = [col.lstrip('\ufeff') if isinstance(col, str) else col for col in df.columns]
 
-    required_columns = get_required_columns(data_type)
+    required_columns = get_summary_required_columns(data_type)
     missing_columns = [col for col in required_columns if col not in df.columns]
     if missing_columns:
         raise KeyError(
@@ -31,13 +32,13 @@ def main() -> None:
     for col in METRIC_COLUMNS:
         df[col] = pd.to_numeric(df[col], errors='coerce').fillna(0)
 
-    df['年份'] = pd.to_numeric(df['年份'], errors='coerce')
-    df = df.dropna(subset=['年份']).copy()
-    df['年份'] = df['年份'].astype(int)
+    df[year_col] = pd.to_numeric(df[year_col], errors='coerce')
+    df = df.dropna(subset=[year_col]).copy()
+    df[year_col] = df[year_col].astype(int)
 
     cases_col, deaths_col, incidence_col, mortality_col = METRIC_COLUMNS
     yearly_df = (
-        df.groupby([group_col, '年份'], as_index=False)
+        df.groupby([group_col, year_col], as_index=False)
         .agg(
             **{
                 cases_col: (cases_col, 'sum'),
@@ -46,7 +47,7 @@ def main() -> None:
                 mortality_col: (mortality_col, 'mean'),
             }
         )
-        .sort_values([group_col, '年份'], ignore_index=True)
+        .sort_values([group_col, year_col], ignore_index=True)
     )
 
     output_file = os.path.join(foldername, f'{group_col}_year_final.csv')


### PR DESCRIPTION
### Summary
- rename the shared schema helpers to match their real semantics and remove the redundant `get_required_columns` wrapper
- narrow `sum_script.py` validation to only the columns it actually needs (`group column`, metrics, and `年份`)
- rename the template helper in `process.py` and update its docstring to reflect that it validates template width and returns the canonical `final.csv` schema

### Why
This addresses the remaining automated review feedback on PR #4 about:
- redundant schema helper indirection
- over-strict summary validation requiring an unused `月份` column
- misleading helper naming/docstring in `process.py`

### Verification
- `python -m py_compile schema.py process.py sum_script.py download.py`
- ran `process.py` for disease `139`, years `2004-2020`, mode `region`
- ran `sum_script.py` for disease `139`, mode `region`
