### PR TITLE
Fix PR5 review follow-ups

### DIFF
--- a/process.py
+++ b/process.py
@@ -48,12 +48,11 @@ def parse_excel_xml(xml_file: str) -> pd.DataFrame:
     return df.astype('float', errors='ignore')
 
 
-def validate_template_and_get_output_columns(template_file: str, data_type: str) -> list[str]:
-    """Validate the template width and return the canonical final.csv schema."""
+def validate_template_and_get_final_csv_columns(template_file: str, data_type: str) -> list[str]:
+    """Validate the template width and return the canonical final.csv columns."""
     template_values = (
-        pd.read_csv(template_file, encoding='utf-8-sig', header=None)
+        pd.read_csv(template_file, encoding='utf-8-sig', header=None, keep_default_na=False)
         .iloc[0]
-        .dropna()
         .astype(str)
         .tolist()
     )
@@ -83,7 +82,7 @@ def main() -> None:
     os.makedirs(foldername, exist_ok=True)
 
     template_file = f'template_{data_type}.csv'
-    template_columns = validate_template_and_get_output_columns(template_file, data_type)
+    template_columns = validate_template_and_get_final_csv_columns(template_file, data_type)
     expected_monthly_columns = len(template_columns) - len(DATE_COLUMNS)
     final_df = pd.DataFrame(columns=template_columns)
 


### PR DESCRIPTION
### Summary
- rename the template helper to `validate_template_and_get_final_csv_columns()` so the name matches the returned schema
- preserve empty header cells when reading the template row by using `keep_default_na=False` instead of dropping NA values before width validation

### Why
This addresses the remaining Copilot feedback on PR #5 about:
- undercounting template columns when empty header cells are present
- helper naming still being slightly misleading relative to `get_final_csv_columns`

### Verification
- `python -m py_compile schema.py process.py sum_script.py download.py`
- ran `process.py` for disease `139`, years `2004-2020`, mode `region`
- ran `sum_script.py` for disease `139`, mode `region`
